### PR TITLE
Change catch-all method from get to all

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function vitePlugin(options) {
       }
 
       // Final catch-all route forwards back to the Vite server
-      fastify.get('/*', function (request) {
+      fastify.all('/*', function (request) {
         /** @type {import('connect').NextFunction} */
         const next = request.raw[nextSymbol];
         next();

--- a/lib/server.js
+++ b/lib/server.js
@@ -50,7 +50,7 @@ export function start(manifest, options) {
   }
   
   // Fallback route
-  fastify.get('/*', async function (request, reply) {
+  fastify.all('/*', async function (request, reply) {
     const routeData = app.match(request.raw, { matchNotFound: true });
     if(routeData) {
       const response = await app.render(request.raw, routeData);


### PR DESCRIPTION
In order to have server endpoints (API Routes) working for all methods we need to listen to "all" methods and not only to `get`.