### PR TITLE
Load server entry through Vite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,8 @@ function vitePlugin(options) {
       });
       
       if(options?.entry) {
-        const setupRoutes = (await import(options.entry.toString())).default;
+        const entryModule = await server.ssrLoadModule(options.entry.toString());
+        const setupRoutes = entryModule.default;
         if(typeof setupRoutes !== 'function') {
           throw new Error(`@matthewp/astro-fastify: ${options.entry.toString()} should export a default function.`);
         }


### PR DESCRIPTION
Closes #1 

This makes it so that the entry module is loaded via Vite in dev. It already is built with Vite during the build so this should be a safe change. Nevertheless, this will be a `major` change.