### PR TITLE
Add response iterator

### DIFF
--- a/lib/response-iterator.js
+++ b/lib/response-iterator.js
@@ -1,3 +1,9 @@
+/**
+ * Original sources:
+ *  - https://github.com/kmalakoff/response-iterator/blob/master/src/index.ts
+ *  - https://github.com/apollographql/apollo-client/blob/main/src/link/http/responseIterator.ts
+ */
+
 var canUseSymbol = typeof Symbol === 'function' &&
     typeof Symbol.for === 'function';
 

--- a/lib/response-iterator.js
+++ b/lib/response-iterator.js
@@ -1,0 +1,172 @@
+var canUseSymbol = typeof Symbol === 'function' &&
+    typeof Symbol.for === 'function';
+
+var canUseAsyncIteratorSymbol = canUseSymbol && Symbol.asyncIterator;
+
+function isNodeResponse(value) {
+    return !!value.body;
+}
+
+function isReadableStream(value) {
+    return !!value.getReader;
+}
+
+function isAsyncIterableIterator(value) {
+    return !!(canUseAsyncIteratorSymbol &&
+        value[Symbol.asyncIterator]);
+}
+
+function isStreamableBlob(value) {
+    return !!value.stream;
+}
+
+function isBlob(value) {
+    return !!value.arrayBuffer;
+}
+
+function isNodeReadableStream(value) {
+    return !!value.pipe;
+}
+
+function asyncIterator(source) {
+    var _a;
+    var iterator = source[Symbol.asyncIterator]();
+    return _a = {
+        next: function () {
+            return iterator.next();
+        }
+    },
+        _a[Symbol.asyncIterator] = function () {
+            return this;
+        },
+        _a;
+}
+
+function readerIterator(reader) {
+    var iterator = {
+        next: function () {
+            return reader.read();
+        },
+    };
+    if (canUseAsyncIteratorSymbol) {
+        iterator[Symbol.asyncIterator] = function () {
+            return this;
+        };
+    }
+    return iterator;
+}
+
+function promiseIterator(promise) {
+    var resolved = false;
+    var iterator = {
+        next: function () {
+            if (resolved)
+                return Promise.resolve({
+                    value: undefined,
+                    done: true,
+                });
+            resolved = true;
+            return new Promise(function (resolve, reject) {
+                promise
+                    .then(function (value) {
+                        resolve({ value: value, done: false });
+                    })
+                    .catch(reject);
+            });
+        },
+    };
+    if (canUseAsyncIteratorSymbol) {
+        iterator[Symbol.asyncIterator] = function () {
+            return this;
+        };
+    }
+    return iterator;
+}
+
+function nodeStreamIterator(stream) {
+    var cleanup = null;
+    var error = null;
+    var done = false;
+    var data = [];
+    var waiting = [];
+    function onData(chunk) {
+        if (error)
+            return;
+        if (waiting.length) {
+            var shiftedArr = waiting.shift();
+            if (Array.isArray(shiftedArr) && shiftedArr[0]) {
+                return shiftedArr[0]({ value: chunk, done: false });
+            }
+        }
+        data.push(chunk);
+    }
+    function onError(err) {
+        error = err;
+        var all = waiting.slice();
+        all.forEach(function (pair) {
+            pair[1](err);
+        });
+        !cleanup || cleanup();
+    }
+    function onEnd() {
+        done = true;
+        var all = waiting.slice();
+        all.forEach(function (pair) {
+            pair[0]({ value: undefined, done: true });
+        });
+        !cleanup || cleanup();
+    }
+    cleanup = function () {
+        cleanup = null;
+        stream.removeListener("data", onData);
+        stream.removeListener("error", onError);
+        stream.removeListener("end", onEnd);
+        stream.removeListener("finish", onEnd);
+        stream.removeListener("close", onEnd);
+    };
+    stream.on("data", onData);
+    stream.on("error", onError);
+    stream.on("end", onEnd);
+    stream.on("finish", onEnd);
+    stream.on("close", onEnd);
+    function getNext() {
+        return new Promise(function (resolve, reject) {
+            if (error)
+                return reject(error);
+            if (data.length)
+                return resolve({ value: data.shift(), done: false });
+            if (done)
+                return resolve({ value: undefined, done: true });
+            waiting.push([resolve, reject]);
+        });
+    }
+    var iterator = {
+        next: function () {
+            return getNext();
+        },
+    };
+    if (canUseAsyncIteratorSymbol) {
+        iterator[Symbol.asyncIterator] = function () {
+            return this;
+        };
+    }
+    return iterator;
+}
+
+export function responseIterator(response) {
+    var body = response;
+    if (isNodeResponse(response))
+        body = response.body;
+    if (isAsyncIterableIterator(body))
+        return asyncIterator(body);
+    if (isReadableStream(body))
+        return readerIterator(body.getReader());
+    if (isStreamableBlob(body)) {
+        return readerIterator(body.stream().getReader());
+    }
+    if (isBlob(body))
+        return promiseIterator(body.arrayBuffer());
+    if (isNodeReadableStream(body))
+        return nodeStreamIterator(body);
+    throw new Error("Unknown body type for responseIterator. Please pass a streamable response.");
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,7 @@ import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import { polyfill } from '@astrojs/webapi';
 import { fileURLToPath } from 'url';
+import { responseIterator } from './response-iterator';
 
 polyfill(globalThis, {
   exclude: 'window document',
@@ -94,7 +95,7 @@ async function writeWebResponse(app, res, webResponse) {
   let headersObj = Object.fromEntries(headers.entries());
   res.writeHead(status, headersObj);
   if (body) {
-    for await (const chunk of /** @type {any} */(body)) {
+    for await (const chunk of /** @type {any} */responseIterator(body)) {
       res.write(chunk);
     }
   }


### PR DESCRIPTION
Hi @matthewp,

Sometimes Astro sends a [ReadableStream as a response](https://github.com/withastro/astro/blob/main/packages/astro/src/runtime/server/render/page.ts#L105) and it raise an error `TypeError: body is not async iterable`.

I added a function to get a response iterator from different response types (sourced from apollo-client).

With this, Fastify can handle all the Astro response types.
