### PR TITLE
docs: js / ts mixed + fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Unlike most adapters, __@matthewp/astro-fastify__ also works in *dev mode*.
 
 ## install
 
-__@matthewp/astro-fastify__ is neededd in production so use `--save`.
+__@matthewp/astro-fastify__ is needed in production so use `--save`.
 
 ```shell
 npm install @matthewp/astro-fastify --save
@@ -25,7 +25,7 @@ import fastify from '@matthewp/astro-fastify';
 export default {
   output: 'server',
   adapter: fastify({
-    entry: new URL('./api/index.js', import.meta.url)
+    entry: new URL('./api/index.ts', import.meta.url)
   })
 };
 ```


### PR DESCRIPTION
Mixed JS / TS examples,  
throws:
```
  Code:
    53280 |         // TODO more info? is this even necessary?
    > 53281 |         throw new Error(`failed to load module for ssr: ${url}`);
```