### PR TITLE
feat: support custom fastify server options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,8 @@ function vitePlugin(options) {
       
       const fastify = Fastify({
         logger: options?.logger ?? true,
-        serverFactory
+        serverFactory,
+        ...options?.fastify ?? {}
       });
       
       if(options?.entry) {
@@ -84,6 +85,7 @@ export default function(options) {
   let args = /** @type {any} */({});
   args.port = options.port;
   args.logger = options.logger ?? true;
+  args.fastify = options.fastify;
   return {
     name: '@matthewp/astro-fastify',
     hooks: {

--- a/lib/server.js
+++ b/lib/server.js
@@ -29,7 +29,8 @@ export function start(manifest, options) {
   const app = new NodeApp(manifest);
   
   const fastify = Fastify({
-    logger: options.logger ?? true
+    logger: options.logger ?? true,
+    ...options.fastify ?? {}
   });
   
   const clientRoot = new URL(options.clientRelative, import.meta.url);

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -6,6 +6,7 @@ export type ServerArgs = {
   assetsPrefix: string;
   port: number | undefined;
   logger: FastifyServerOptions['logger'] | undefined;
+  fastify?: Omit<FastifyServerOptions, 'logger'>;
 };
 
 export type DefineFastifyRoutes = (fastify: FastifyInstance) => void;
@@ -29,6 +30,10 @@ export type IntegrationOptions = {
    * any of the options specified by Fastify: https://www.fastify.io/docs/latest/Reference/Logging/
    */
   logger?: FastifyServerOptions['logger'];
+  /**
+   * Specifies fastify server options.
+   */
+  fastify?: Omit<FastifyServerOptions, 'logger'>;
 };
 
 export default function(opts: IntegrationOptions): AstroIntegration;


### PR DESCRIPTION
Usage example:
```ts
adapter: fastify({
	entry: new URL('./api/index.ts', import.meta.url),

	fastify: { // FastifyServerOptions
		ajv: {
			customOptions: {
				strict: false,
			},
		},
	},
}),
```