### PR TITLE
Fix build issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,7 +117,7 @@ export default function(options) {
           }
         }
       },
-      'astro:build:start'({ buildConfig }) {
+      'config.build'({ buildConfig }) {
         args.clientRelative = relative(fileURLToPath(buildConfig.server), fileURLToPath(buildConfig.client));
       }
     }


### PR DESCRIPTION
Build did not work on latest version of "create astro".

```
  "dependencies": {
    "astro": "^2.0.2"
  },
  "devDependencies": {
    "@matthewp/astro-fastify": "^2.0.3"
  }
```

[Here is](https://github.com/withastro/astro/pull/5056) the change that broke build.