### PR TITLE
change static assets destination to be _astro folder

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,21 +109,14 @@ export default function(options) {
         });
       },
       'astro:build:setup'({ vite, target }) {
-        args.assetsPrefix = '/assets/';
+        args.assetsPrefix = '/_astro/';
         if(target === 'client') {
           const outputOptions = vite?.build?.rollupOptions?.output;
           if(outputOptions && !Array.isArray(outputOptions)) {
             Object.assign(outputOptions, {
-              entryFileNames: 'assets/[name].[hash].js',
-              chunkFileNames: 'assets/chunks/[name].[hash].js',
-              assetFileNames: 'assets/[name].[hash][extname]'
-            });
-          }
-        } else {
-          const outputOptions = vite?.build?.rollupOptions?.output;
-          if(outputOptions && !Array.isArray(outputOptions)) {
-            Object.assign(outputOptions, {
-              assetFileNames: 'assets/[name].[hash][extname]'
+              entryFileNames: '_astro/[name].[hash].js',
+              chunkFileNames: '_astro/chunks/[name].[hash].js',
+              assetFileNames: '_astro/[name].[hash][extname]'
             });
           }
         }

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ Which will create an entrypoint for your server, by default `dist/server/entry.m
 node dist/server/entry.mjs
 ```
 
-Configure your host to run this script. Assets and JavaScript are output to `dist/client/assets/`. You can configure your CDN to serve these files more efficiently and with long-lived cache headers.
+Configure your host to run this script. Assets and JavaScript are output to `dist/client/_astro/`. You can configure your CDN to serve these files more efficiently and with long-lived cache headers.
 
 ## License
 


### PR DESCRIPTION
## Context

After Astro V2, the static assets destination is `dist/client/_astro` folder.

## Changes
- Align static files destination to be same as Astro V2


Before:

![image](https://user-images.githubusercontent.com/73230019/216432730-2abc315a-6f34-4a87-9be0-925a8f181572.png)

After:

![image](https://user-images.githubusercontent.com/73230019/216432769-762a7ccd-fb26-4296-9c3e-587f75357e55.png)
