### PR TITLE
fix: fix null httpServer error during build and check, fixes #19

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 import { relative } from 'path';
 import { fileURLToPath } from 'url';
 import Fastify from 'fastify';
+import http from 'http';
 
 /**
 * @typedef {import('astro').AstroUserConfig} AstroUserConfig
@@ -39,7 +40,7 @@ function vitePlugin(options) {
           req[nextSymbol] = next;
           handler(req, res);
         });
-        return /** @type {import('http').Server} */(server.httpServer);
+        return /** @type {import('http').Server} */(server.httpServer ?? new http.Server());
       }
       
       const fastify = Fastify({


### PR DESCRIPTION
The vite dev server seem to run in middleware mode (httpServer is null in this case), that's why we need to create an own server to pass into fastify constructor