### PR TITLE
consider bumping dependency entries to get rid of warnings for astro 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matthewp/astro-fastify",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Fastify integration for Astro",
   "main": "lib/index.js",
   "types": "lib/types.d.ts",
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/matthewp/astro-fastify#readme",
   "peerDependencies": {
-    "astro": "^1.1.3 || ^2.0.0"
+    "astro": "^1.1.3 || ^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "@astrojs/webapi": "^1.0.0",
@@ -34,6 +34,6 @@
     "fastify": "^4.5.3"
   },
   "devDependencies": {
-    "astro": "^2.0.0"
+    "astro": "^3.0.0"
   }
 }


### PR DESCRIPTION
adding astro@^3.0.0 to list of peer dependencies, and setting it as dev dependency