### PR TITLE
Add basic supportedAstroFeatures to index.js, to enable this to work with Astro 4.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,10 @@ export default function(options) {
           name: '@matthewp/astro-fastify:adapter',
           serverEntrypoint: serverPath,
           exports: ['start'],
-          args: args
+          args: args,
+          supportedAstroFeatures: {
+            serverOutput: 'stable'
+          }
         });
       },
       'astro:build:setup'({ vite, target }) {


### PR DESCRIPTION
Add limited `supportedAstroFeatures` map to get this working with Astro 4.0.

I'm not familiar enough with what other features this supports (or Astro, really) to know if this is the ideal/complete fix, but the `serverOutput` feature was necessary to get this working for me locally. 

Address #29 