### PR TITLE
fix: next might not be a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,9 @@ function vitePlugin(options) {
       fastify.all('/*', function (request) {
         /** @type {import('connect').NextFunction} */
         const next = request.raw[nextSymbol];
-        next();
+        if (typeof next === "function") {
+          next();
+        }
       });
       
       await fastify.ready();


### PR DESCRIPTION
# What is the problem?

I have the following configuration:

```js
import { defineConfig } from "astro/config";
import react from "@astrojs/react";
import tailwind from "@astrojs/tailwind";
import fastify from "@matthewp/astro-fastify";

// https://astro.build/config
export default defineConfig({
  integrations: [react(), tailwind()],
  output: "server",
  adapter: fastify({
    entry: new URL("./api/index.ts", import.meta.url),
  }),
  server: {
    port: +(process.env.PORT || 4321),
  },
});

```

and the following `./api/index.ts`:
```ts
import type { DefineFastifyRoutes } from "@matthewp/astro-fastify";

const defineRoutes: DefineFastifyRoutes = (fastify) => {
  fastify.register(import("@fastify/websocket"));
  fastify.register(async function (fastify) {
    fastify.get("/ws", { websocket: true }, (connection) => {
      // console.log("have here websocket", connection.socket);

      setTimeout(() => {
        connection.socket.send(`hii`);
      }, 2000);
    });
  });
};

export default defineRoutes;
```

I have received the following error :
in short: `"msg":"next is not a function"`
in long:
```json
{"level":50,"time":1706989967311,"pid":56885,"hostname":"sagi-21D8000EIV","reqId":"req-a1","req":{"method":"GET","url":"/","hostname":"localhost:4321","remoteAddress":"127.0.0.1","remotePort":50318},"res":{"statusCode":500},"err":{"type":"TypeError","message":"next is not a function","stack":"TypeError: next is not a function\n    at Object.<anonymous> (file:///home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/@matthewp+astro-fastify@3.1.0_astro@4.2.4/node_modules/@matthewp/astro-fastify/lib/index.js:71:9)\n    at preHandlerCallback (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/handleRequest.js:137:37)\n    at validationCompleted (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/handleRequest.js:121:5)\n    at preValidationCallback (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/handleRequest.js:98:5)\n    at handler (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/handleRequest.js:75:7)\n    at handleRequest (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/handleRequest.js:24:5)\n    at runPreParsing (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/route.js:609:5)\n    at next (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/hooks.js:233:9)\n    at Object.<anonymous> (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/@fastify+websocket@8.3.1/node_modules/@fastify/websocket/index.js:91:5)\n    at hookIterator (/home/sagi/Desktop/companies/ordibets/ordibets-app/node_modules/.pnpm/fastify@4.26.0/node_modules/fastify/lib/hooks.js:405:10)"},"msg":"next is not a function"}
```

which pointed out for line 71.

## What did I do?
Just added an if for the line 71.
