### PR TITLE
bugfix: socket + post with data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,7 @@ function vitePlugin(options) {
       }
       
       const fastify = Fastify({
+      fastify = Fastify({
         logger: options?.logger ?? true,
         serverFactory
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,6 @@ function vitePlugin(options) {
         return /** @type {import('http').Server} */(server.httpServer ?? new http.Server());
       }
       
-      const fastify = Fastify({
       fastify = Fastify({
         logger: options?.logger ?? true,
         serverFactory

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,11 +40,18 @@ function vitePlugin(options) {
     async configureServer(server) {
       const nextSymbol = Symbol('next');
       
+      /** @type {import('fastify').FastifyInstance} */
+      let fastify;
+
       /** @type {import('fastify').FastifyServerFactory} */
       const serverFactory = (handler, opts) => {
         server.middlewares.use((req, res, next) => {
-          req[nextSymbol] = next;
-          handler(req, res);
+          if (fastify.hasRoute({ method: req.method, url: req.url })) {
+            req[nextSymbol] = next;
+            handler(req, res);
+          } else {
+            next();
+          }
         });
         return /** @type {import('http').Server} */(server.httpServer ?? new http.Server());
       }
@@ -63,16 +70,17 @@ function vitePlugin(options) {
         }
         setupRoutes(fastify);
       }
-      
-      // Final catch-all route forwards back to the Vite server
-      fastify.all('/*', function (request) {
+
+      // The vite socket can get to here...
+      // Relevant also when registered @fastify/websocket
+      fastify.get("/", function (request) {
         /** @type {import('connect').NextFunction} */
         const next = request.raw[nextSymbol];
         if (typeof next === "function") {
           next();
         }
       });
-      
+
       await fastify.ready();
     },
     transform(code, id) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,3 @@
-import { Request } from "undici";
 import { IncomingMessage } from "node:http";
 import { NodeApp } from "astro/app/node";
 import Fastify from "fastify";

--- a/lib/server.js
+++ b/lib/server.js
@@ -161,8 +161,7 @@ async function writeWebResponse(app, res, webResponse) {
  */
 function revertToRequest(request) {
   const url = createURL(request);
-  const newRequest = NodeApp.createRequest({
-    url,
+  const newRequest = new Request(url, {
     method: request.method,
     headers: request.headers,
     body: getBody(request),
@@ -174,7 +173,7 @@ function revertToRequest(request) {
  * @param {import('fastify').FastifyRequest} request
  */
 function getBody(request) {
-  const contentType = request.headers["content-type"].toLowerCase();
+  const contentType = request.headers["content-type"];
   switch (contentType) {
     case "application/x-www-form-urlencoded": {
       return Object.keys(request.body).reduce((urlEncode, key) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -161,7 +161,8 @@ async function writeWebResponse(app, res, webResponse) {
  */
 function revertToRequest(request) {
   const url = createURL(request);
-  const newRequest = new Request(url, {
+  const newRequest = NodeApp.createRequest({
+    url,
     method: request.method,
     headers: request.headers,
     body: getBody(request),

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,5 @@
+import { Request } from "undici";
+import { IncomingMessage } from "node:http";
 import { NodeApp } from "astro/app/node";
 import Fastify from "fastify";
 import fastifyStatic from "@fastify/static";
@@ -58,9 +60,13 @@ export function start(manifest, options) {
    * @param {import('fastify').FastifyReply} reply
    */
   const rootHandler = async (request, reply) => {
-    const routeData = app.match(request.raw, { matchNotFound: true });
+    let rawRequest = request.raw;
+    if (IncomingMessage.isDisturbed(rawRequest)) {
+      rawRequest = revertToRequest(request);
+    }
+    const routeData = app.match(rawRequest, { matchNotFound: true });
     if (routeData) {
-      const response = await app.render(request.raw, { routeData });
+      const response = await app.render(rawRequest, { routeData });
 
       await writeWebResponse(app, reply.raw, response);
     } else {
@@ -149,6 +155,60 @@ async function writeWebResponse(app, res, webResponse) {
     }
   }
   res.end();
+}
+
+/**
+ * @param {import('fastify').FastifyRequest} request
+ */
+function revertToRequest(request) {
+  const url = createURL(request);
+  const newRequest = new Request(url, {
+    method: request.method,
+    headers: request.headers,
+    body: getBody(request),
+  });
+  return newRequest;
+}
+
+/**
+ * @param {import('fastify').FastifyRequest} request
+ */
+function getBody(request) {
+  const contentType = request.headers["content-type"].toLowerCase();
+  switch (contentType) {
+    case "application/x-www-form-urlencoded": {
+      return Object.keys(request.body).reduce((urlEncode, key) => {
+        urlEncode.append(key, request.body[key]);
+        return urlEncode;
+      }, new URLSearchParams());
+    }
+    default:
+      return request.body;
+  }
+}
+
+/**
+ * @param {import('fastify').FastifyRequest} request
+ */
+function createURL(request) {
+  const url = new URL(
+    `${request.url}`,
+    `${request.protocol}://${request.hostname}`,
+  );
+  if (typeof query === "string") {
+    url.search = query;
+  } else if (typeof query === "object") {
+    Object.entries(query).forEach(([key, val]) => {
+      if (typeof val === "string") {
+        url.searchParams.append(key, val);
+      } else {
+        val.forEach((innerVal) => {
+          url.searchParams.append(key, innerVal);
+        });
+      }
+    });
+  }
+  return url;
 }
 
 export function createExports(manifest, options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matthewp/astro-fastify",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@matthewp/astro-fastify",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@astrojs/webapi": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@astrojs/webapi": "^1.0.0",
         "@fastify/static": "^6.5.0",
-        "fastify": "^4.5.3"
+        "fastify": "^4.5.3",
+        "undici": "^6.6.2"
       },
       "devDependencies": {
         "astro": "^4.3.5"
@@ -881,6 +882,14 @@
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@fastify/error": {
@@ -6801,6 +6810,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/undici": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.2.tgz",
+      "integrity": "sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
     "node_modules/unherit": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-3.0.1.tgz",
@@ -7832,6 +7852,11 @@
         "ajv-formats": "^2.1.1",
         "fast-uri": "^2.0.0"
       }
+    },
+    "@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
     },
     "@fastify/error": {
       "version": "3.4.1",
@@ -12040,6 +12065,14 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true
+    },
+    "undici": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.2.tgz",
+      "integrity": "sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==",
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
+      }
     },
     "unherit": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   "dependencies": {
     "@astrojs/webapi": "^1.0.0",
     "@fastify/static": "^6.5.0",
-    "fastify": "^4.5.3",
-    "undici": "^6.6.2"
+    "fastify": "^4.5.3"
   },
   "devDependencies": {
     "astro": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matthewp/astro-fastify",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A Fastify integration for Astro",
   "main": "lib/index.js",
   "types": "lib/types.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@astrojs/webapi": "^1.0.0",
     "@fastify/static": "^6.5.0",
-    "fastify": "^4.5.3"
+    "fastify": "^4.5.3",
+    "undici": "^6.6.2"
   },
   "devDependencies": {
     "astro": "^4.3.5"


### PR DESCRIPTION
Hi!

Found 2 problems:
1. making POST requests to pages with data (in any non empty format) doesn't return.
2. When using the @fastify/websocket, the vite websocket runs partially on fastify.

Fixed them.

However:
With these changes.,only the requests that were explicit towards fastify will be caught,
unlike the previous version where all was caught.

Upside:
I believe this is slightly faster then the previous algorithm, because we are dividing only for relevancy. 